### PR TITLE
Replace execution timeout with -1

### DIFF
--- a/jb/_config.yml
+++ b/jb/_config.yml
@@ -16,7 +16,7 @@ repository:
 
 execute:
   execute_notebooks: 'force'
-  timeout: null
+  timeout: -1
 
 # See https://github.com/executablebooks/jupyter-book/issues/954#issuecomment-688220038
 sphinx:


### PR DESCRIPTION
As https://github.com/executablebooks/jupyter-book/issues/948 was fixed in https://github.com/executablebooks/jupyter-book/commit/282ffde4b3ad0dc9c8db2e1ec4eb5dabfb520830